### PR TITLE
Allow /t=<milliseconds> parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3
+
+- Accept /t=<milliseconds> parameter for backwards compatibility.
+  Ignore provided timeout.
+
 ## 0.2.2
 
 - Fixed bug that was introduced in commit 95912a4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.3
 
+- Implemented GET <queue-name>/close/open
 - Accept /t=<milliseconds> parameter for backwards compatibility.
   Ignore provided timeout.
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,18 @@ mkdir ./data
 2015/09/22 06:29:38 data directory:  ./data
 ```
 
+## Protocol
+
+Siberite follows the same protocol as [Kestrel](http://github.com/robey/kestrel/blob/master/docs/guide.md#memcache),
+which is the memcache TCP text protocol.
+
+[List of compaible clients](docs/clients.md)
+
+
 ## Usage
 
 ```
 telnet localhost 22133
-rying ::1...
 Connected to localhost.
 Escape character is '^]'.
 
@@ -69,12 +76,6 @@ END
 # flush_all
 ```
 
-
-## Protocol
-
-Siberite follows the same protocol as [Kestrel](http://github.com/robey/kestrel/blob/master/docs/guide.md#memcache), which is the memcache
-protocol.
-
 ## Todo
 
   - close an exisitng item read and open a new one in one command GET work/close/open
@@ -82,3 +83,4 @@ protocol.
 ## Not supported
 
   - waiting a given time limit for a new item to arrive /t=<milliseconds>
+

--- a/README.md
+++ b/README.md
@@ -70,15 +70,12 @@ END
 # other commands:
 # get work/peek
 # get work/open
+# get work/close/open
 # get work/abort
 # flush work
 # delete work
 # flush_all
 ```
-
-## Todo
-
-  - close an exisitng item read and open a new one in one command GET work/close/open
 
 ## Not supported
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ END
 # flush_all
 ```
 
+## Todo
+
+  - some stats
+
 ## Not supported
 
   - waiting a given time limit for a new item to arrive /t=<milliseconds>

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -56,11 +56,11 @@ func Test_NewSession_FinishSession(t *testing.T) {
 	mockTCPConn := NewMockTCPConn()
 	c := NewSession(mockTCPConn, repo)
 
-	assert.Equal(t, repo.Stats.CurrentConnections, uint64(1))
-	assert.Equal(t, repo.Stats.TotalConnections, uint64(1))
+	assert.Equal(t, uint64(1), repo.Stats.CurrentConnections)
+	assert.Equal(t, uint64(1), repo.Stats.TotalConnections)
 
 	c.FinishSession()
-	assert.Equal(t, repo.Stats.CurrentConnections, uint64(0))
+	assert.Equal(t, uint64(0), repo.Stats.CurrentConnections)
 }
 
 func Test_ReadFirstMessage(t *testing.T) {
@@ -74,12 +74,12 @@ func Test_ReadFirstMessage(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "GET work\r\n")
 	message, err := controller.ReadFirstMessage()
 	assert.Nil(t, err)
-	assert.Equal(t, message, "GET work\r\n")
+	assert.Equal(t, "GET work\r\n", message)
 
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "SET work 0 0 10\r\n0123456789\r\n")
 	message, err = controller.ReadFirstMessage()
 	assert.Nil(t, err)
-	assert.Equal(t, message, "SET work 0 0 10\r\n")
+	assert.Equal(t, "SET work 0 0 10\r\n", message)
 }
 
 func Test_UnknownCommand(t *testing.T) {
@@ -91,8 +91,8 @@ func Test_UnknownCommand(t *testing.T) {
 	controller := NewSession(mockTCPConn, repo)
 
 	err = controller.UnknownCommand()
-	assert.Equal(t, err.Error(), "ERROR Unknown command")
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "ERROR Unknown command\r\n")
+	assert.Equal(t, "ERROR Unknown command", err.Error())
+	assert.Equal(t, "ERROR Unknown command\r\n", mockTCPConn.WriteBuffer.String())
 
 }
 
@@ -105,5 +105,5 @@ func Test_SendError(t *testing.T) {
 	controller := NewSession(mockTCPConn, repo)
 
 	controller.SendError("Test error message")
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "Test error message\r\n")
+	assert.Equal(t, "Test error message\r\n", mockTCPConn.WriteBuffer.String())
 }

--- a/controller/delete_test.go
+++ b/controller/delete_test.go
@@ -24,12 +24,12 @@ func Test_Delete(t *testing.T) {
 	assert.Nil(t, err)
 	response, err := mockTCPConn.WriteBuffer.ReadString('\n')
 	assert.Nil(t, err)
-	assert.Equal(t, response, "END\r\n")
+	assert.Equal(t, "END\r\n", response)
 
 	command = []string{"DELETE", "test"}
 	err = controller.Delete(command)
 	assert.Nil(t, err)
 	response, err = mockTCPConn.WriteBuffer.ReadString('\n')
 	assert.Nil(t, err)
-	assert.Equal(t, response, "END\r\n")
+	assert.Equal(t, "END\r\n", response)
 }

--- a/controller/dispatch_test.go
+++ b/controller/dispatch_test.go
@@ -128,5 +128,5 @@ func Test_Dispatch(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "flush_all\r\n")
 	err = controller.Dispatch()
 	assert.Nil(t, err)
-	assert.Equal(t, "END\r\n", mockTCPConn.WriteBuffer.String())
+	assert.Equal(t, "Flushed all queues.\r\n", mockTCPConn.WriteBuffer.String())
 }

--- a/controller/dispatch_test.go
+++ b/controller/dispatch_test.go
@@ -22,7 +22,7 @@ func Test_Dispatch(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "set test 0 0 1\r\n1\r\n")
 	err = controller.Dispatch()
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "STORED\r\n")
+	assert.Equal(t, "STORED\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -32,7 +32,7 @@ func Test_Dispatch(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "20\r\n")
 	err = controller.Dispatch()
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "STORED\r\n")
+	assert.Equal(t, "STORED\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -46,7 +46,7 @@ func Test_Dispatch(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "1\r\n")
 	err = controller.Dispatch()
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "STORED\r\n")
+	assert.Equal(t, "STORED\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -54,7 +54,7 @@ func Test_Dispatch(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "get test\r\n")
 	err = controller.Dispatch()
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "VALUE test 0 1\r\n1\r\nEND\r\n")
+	assert.Equal(t, "VALUE test 0 1\r\n1\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -62,7 +62,7 @@ func Test_Dispatch(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "get test/open\r\n")
 	err = controller.Dispatch()
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "VALUE test 0 2\r\n20\r\nEND\r\n")
+	assert.Equal(t, "VALUE test 0 2\r\n20\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -70,7 +70,7 @@ func Test_Dispatch(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "GET test/abort\r\n")
 	err = controller.Dispatch()
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "END\r\n")
+	assert.Equal(t, "END\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -78,7 +78,7 @@ func Test_Dispatch(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "get test/open\r\n")
 	err = controller.Dispatch()
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "VALUE test 0 2\r\n20\r\nEND\r\n")
+	assert.Equal(t, "VALUE test 0 2\r\n20\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -86,7 +86,7 @@ func Test_Dispatch(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "get test/close\r\n")
 	err = controller.Dispatch()
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "END\r\n")
+	assert.Equal(t, "END\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -94,7 +94,7 @@ func Test_Dispatch(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "version\r\n")
 	err = controller.Dispatch()
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "VERSION "+repo.Stats.Version+"\r\n")
+	assert.Equal(t, "VERSION "+repo.Stats.Version+"\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -112,7 +112,7 @@ func Test_Dispatch(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "flush test\r\n")
 	err = controller.Dispatch()
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "END\r\n")
+	assert.Equal(t, "END\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -120,7 +120,7 @@ func Test_Dispatch(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "DELETE test\r\n")
 	err = controller.Dispatch()
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "END\r\n")
+	assert.Equal(t, "END\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -128,5 +128,5 @@ func Test_Dispatch(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "flush_all\r\n")
 	err = controller.Dispatch()
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "END\r\n")
+	assert.Equal(t, "END\r\n", mockTCPConn.WriteBuffer.String())
 }

--- a/controller/flush_all.go
+++ b/controller/flush_all.go
@@ -15,7 +15,7 @@ func (self *Controller) FlushAll() error {
 		log.Printf("Can't flush all queues: %s", err.Error())
 		return errors.New("SERVER_ERROR " + err.Error())
 	}
-	fmt.Fprint(self.rw.Writer, "END\r\n")
+	fmt.Fprint(self.rw.Writer, "Flushed all queues.\r\n")
 	self.rw.Writer.Flush()
 	return nil
 }

--- a/controller/flush_all_test.go
+++ b/controller/flush_all_test.go
@@ -19,5 +19,5 @@ func Test_FlushAll(t *testing.T) {
 	assert.Nil(t, err)
 	response, err := mockTCPConn.WriteBuffer.ReadString('\n')
 	assert.Nil(t, err)
-	assert.Equal(t, response, "END\r\n")
+	assert.Equal(t, "END\r\n", response)
 }

--- a/controller/flush_all_test.go
+++ b/controller/flush_all_test.go
@@ -19,5 +19,5 @@ func Test_FlushAll(t *testing.T) {
 	assert.Nil(t, err)
 	response, err := mockTCPConn.WriteBuffer.ReadString('\n')
 	assert.Nil(t, err)
-	assert.Equal(t, "END\r\n", response)
+	assert.Equal(t, "Flushed all queues.\r\n", response)
 }

--- a/controller/flush_test.go
+++ b/controller/flush_test.go
@@ -24,12 +24,12 @@ func Test_Flush(t *testing.T) {
 	assert.Nil(t, err)
 	response, err := mockTCPConn.WriteBuffer.ReadString('\n')
 	assert.Nil(t, err)
-	assert.Equal(t, response, "END\r\n")
+	assert.Equal(t, "END\r\n", response)
 
 	command = []string{"FLUSH", "test"}
 	err = controller.Flush(command)
 	assert.Nil(t, err)
 	response, err = mockTCPConn.WriteBuffer.ReadString('\n')
 	assert.Nil(t, err)
-	assert.Equal(t, response, "END\r\n")
+	assert.Equal(t, "END\r\n", response)
 }

--- a/controller/get_test.go
+++ b/controller/get_test.go
@@ -7,6 +7,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_parseGetCommand(t *testing.T) {
+	testCases := map[string]string{
+		"work":                         "",
+		"work/open":                    "open",
+		"work/close":                   "close",
+		"work/abort":                   "abort",
+		"work/peek":                    "peek",
+		"work/t=10":                    "",
+		"work/t=10/t=100/t=1234567890": "",
+		"work/t=10/open":               "open",
+		"work/open/t=10":               "open",
+		"work/close/open/t=10":         "close/open",
+		"work/close/t=10/open/abort":   "close/open/abort",
+	}
+
+	for input, subCommand := range testCases {
+		cmd := parseGetCommand([]string{"get", input})
+		assert.Equal(t, "get", cmd.Name, input)
+		assert.Equal(t, "work", cmd.QueueName, input)
+		assert.Equal(t, subCommand, cmd.SubCommand, input)
+	}
+}
+
 // Initialize queue 'test' with 1 item
 // get test = value
 // get test = empty
@@ -30,7 +53,7 @@ func Test_Get(t *testing.T) {
 	command := []string{"get", "test"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "VALUE test 0 10\r\n0123456789\r\nEND\r\n")
+	assert.Equal(t, "VALUE test 0 10\r\n0123456789\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -39,7 +62,7 @@ func Test_Get(t *testing.T) {
 	command = []string{"get", "test"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "END\r\n")
+	assert.Equal(t, "END\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -48,7 +71,7 @@ func Test_Get(t *testing.T) {
 	command = []string{"get", "test/close"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "END\r\n")
+	assert.Equal(t, "END\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -57,7 +80,7 @@ func Test_Get(t *testing.T) {
 	command = []string{"get", "test/close"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "END\r\n")
+	assert.Equal(t, "END\r\n", mockTCPConn.WriteBuffer.String())
 }
 
 // Initialize test queue with 4 items
@@ -90,14 +113,14 @@ func Test_GetOpen(t *testing.T) {
 	command := []string{"get", "test/open"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "VALUE test 0 1\r\n1\r\nEND\r\n")
+	assert.Equal(t, "VALUE test 0 1\r\n1\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
 	// get test = error
 	command = []string{"get", "test"}
 	err = controller.Get(command)
-	assert.Equal(t, err.Error(), "CLIENT_ERROR Close current item first")
+	assert.Equal(t, "CLIENT_ERROR Close current item first", err.Error())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -105,7 +128,7 @@ func Test_GetOpen(t *testing.T) {
 	command = []string{"get", "test/close"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "END\r\n")
+	assert.Equal(t, "END\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -113,7 +136,7 @@ func Test_GetOpen(t *testing.T) {
 	command = []string{"get", "test/open"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "VALUE test 0 1\r\n2\r\nEND\r\n")
+	assert.Equal(t, "VALUE test 0 1\r\n2\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
 
 	// get test/open = error
 	command = []string{"get", "test/open"}
@@ -126,7 +149,7 @@ func Test_GetOpen(t *testing.T) {
 	command = []string{"get", "test/abort"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "END\r\n")
+	assert.Equal(t, "END\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -134,7 +157,7 @@ func Test_GetOpen(t *testing.T) {
 	command = []string{"get", "test/open"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "VALUE test 0 1\r\n2\r\nEND\r\n")
+	assert.Equal(t, "VALUE test 0 1\r\n2\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -142,7 +165,7 @@ func Test_GetOpen(t *testing.T) {
 	command = []string{"get", "test/peek"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "VALUE test 0 1\r\n3\r\nEND\r\n")
+	assert.Equal(t, "VALUE test 0 1\r\n3\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -150,7 +173,7 @@ func Test_GetOpen(t *testing.T) {
 	command = []string{"get", "test/close"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "END\r\n")
+	assert.Equal(t, "END\r\n", mockTCPConn.WriteBuffer.String())
 }
 
 // Initialize test queue with 2 items
@@ -177,7 +200,7 @@ func Test_GetOpen_Disconnect(t *testing.T) {
 	command := []string{"get", "test/open"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "VALUE test 0 1\r\n1\r\nEND\r\n")
+	assert.Equal(t, "VALUE test 0 1\r\n1\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -190,28 +213,80 @@ func Test_GetOpen_Disconnect(t *testing.T) {
 	command = []string{"get", "test"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "VALUE test 0 1\r\n1\r\nEND\r\n")
+	assert.Equal(t, "VALUE test 0 1\r\n1\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
 }
 
-func Test_parseGetCommand(t *testing.T) {
-	testCases := map[string]string{
-		"work":                         "",
-		"work/open":                    "open",
-		"work/close":                   "close",
-		"work/abort":                   "abort",
-		"work/peek":                    "peek",
-		"work/t=10":                    "",
-		"work/t=10/t=100/t=1234567890": "",
-		"work/t=10/open":               "open",
-		"work/open/t=10":               "open",
-		"work/close/open/t=10":         "close/open",
-		"work/close/t=10/open/abort":   "close/open/abort",
-	}
+// Initialize test queue with 4 items
+// get test/close/open = value
+// get test = error
+// get test/t=10/close/open = value
+// get test/close/open/t=1000 = next value
+// FinishSession (disconnect)
+// get test/close/t=88/open = same value
+func Test_GetCloseOpen(t *testing.T) {
+	repo, err := repository.Initialize(dir)
+	defer repo.CloseAllQueues()
+	assert.Nil(t, err)
 
-	for input, subCommand := range testCases {
-		cmd := parseGetCommand([]string{"get", input})
-		assert.Equal(t, "get", cmd.Name, input)
-		assert.Equal(t, "work", cmd.QueueName, input)
-		assert.Equal(t, subCommand, cmd.SubCommand, input)
-	}
+	mockTCPConn := NewMockTCPConn()
+	controller := NewSession(mockTCPConn, repo)
+
+	repo.FlushQueue("test")
+	q, err := repo.GetQueue("test")
+	assert.Nil(t, err)
+
+	q.Enqueue([]byte("1"))
+	q.Enqueue([]byte("2"))
+	q.Enqueue([]byte("3"))
+	q.Enqueue([]byte("4"))
+
+	// get test/close/open = 1
+	command := []string{"get", "test/close/open"}
+	err = controller.Get(command)
+	assert.Nil(t, err)
+	assert.Equal(t, "VALUE test 0 1\r\n1\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
+
+	mockTCPConn.WriteBuffer.Reset()
+
+	// get test = error
+	command = []string{"get", "test"}
+	err = controller.Get(command)
+	assert.Equal(t, err.Error(), "CLIENT_ERROR Close current item first")
+
+	mockTCPConn.WriteBuffer.Reset()
+
+	// get test/abort = value
+	command = []string{"get", "test/abort"}
+	err = controller.Get(command)
+	assert.Nil(t, err)
+	assert.Equal(t, "END\r\n", mockTCPConn.WriteBuffer.String())
+
+	mockTCPConn.WriteBuffer.Reset()
+
+	// get test/t=10/close/open = value
+	command = []string{"get", "test/t=10/close/open"}
+	err = controller.Get(command)
+	assert.Nil(t, err)
+	assert.Equal(t, "VALUE test 0 1\r\n1\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
+
+	mockTCPConn.WriteBuffer.Reset()
+
+	// get test/close/open/t=1000 = next value
+	command = []string{"get", "test/close/open/t=1000"}
+	err = controller.Get(command)
+	assert.Nil(t, err)
+	assert.Equal(t, "VALUE test 0 1\r\n2\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
+
+	mockTCPConn.WriteBuffer.Reset()
+
+	controller.FinishSession()
+
+	mockTCPConn = NewMockTCPConn()
+	controller = NewSession(mockTCPConn, repo)
+
+	// get test = same value
+	command = []string{"get", "test/t=88/open"}
+	err = controller.Get(command)
+	assert.Nil(t, err)
+	assert.Equal(t, "VALUE test 0 1\r\n2\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
 }

--- a/controller/get_test.go
+++ b/controller/get_test.go
@@ -192,3 +192,26 @@ func Test_GetOpen_Disconnect(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "VALUE test 0 1\r\n1\r\nEND\r\n")
 }
+
+func Test_parseGetCommand(t *testing.T) {
+	testCases := map[string]string{
+		"work":                         "",
+		"work/open":                    "open",
+		"work/close":                   "close",
+		"work/abort":                   "abort",
+		"work/peek":                    "peek",
+		"work/t=10":                    "",
+		"work/t=10/t=100/t=1234567890": "",
+		"work/t=10/open":               "open",
+		"work/open/t=10":               "open",
+		"work/close/open/t=10":         "close/open",
+		"work/close/t=10/open/abort":   "close/open/abort",
+	}
+
+	for input, subCommand := range testCases {
+		cmd := parseGetCommand([]string{"get", input})
+		assert.Equal(t, "get", cmd.Name, input)
+		assert.Equal(t, "work", cmd.QueueName, input)
+		assert.Equal(t, subCommand, cmd.SubCommand, input)
+	}
+}

--- a/controller/set_test.go
+++ b/controller/set_test.go
@@ -21,7 +21,7 @@ func Test_Set(t *testing.T) {
 
 	err = controller.Set(command)
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "STORED\r\n")
+	assert.Equal(t, "STORED\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -29,7 +29,7 @@ func Test_Set(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "0\r\n")
 
 	err = controller.Set(command)
-	assert.Equal(t, err.Error(), "ERROR Invalid input")
+	assert.Equal(t, "ERROR Invalid input", err.Error())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -37,7 +37,7 @@ func Test_Set(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "0123567890\r\n")
 
 	err = controller.Set(command)
-	assert.Equal(t, err.Error(), "ERROR Invalid <bytes> number")
+	assert.Equal(t, "ERROR Invalid <bytes> number", err.Error())
 
 	mockTCPConn.WriteBuffer.Reset()
 
@@ -45,5 +45,5 @@ func Test_Set(t *testing.T) {
 	fmt.Fprintf(&mockTCPConn.ReadBuffer, "01235678901234567890\r\n")
 
 	err = controller.Set(command)
-	assert.Equal(t, err.Error(), "CLIENT_ERROR bad data chunk")
+	assert.Equal(t, "CLIENT_ERROR bad data chunk", err.Error())
 }

--- a/controller/stats_test.go
+++ b/controller/stats_test.go
@@ -34,5 +34,5 @@ func Test_Stats(t *testing.T) {
 		"STAT queue_test_open_transactions 0\r\n" +
 		"END\r\n"
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), statsResponse)
+	assert.Equal(t, statsResponse, mockTCPConn.WriteBuffer.String())
 }

--- a/controller/version_test.go
+++ b/controller/version_test.go
@@ -16,5 +16,5 @@ func Test_Version(t *testing.T) {
 
 	err = controller.Version()
 	assert.Nil(t, err)
-	assert.Equal(t, mockTCPConn.WriteBuffer.String(), "VERSION "+repo.Stats.Version+"\r\n")
+	assert.Equal(t, "VERSION "+repo.Stats.Version+"\r\n", mockTCPConn.WriteBuffer.String())
 }

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,0 +1,17 @@
+## Supported clients
+
+You should be able to use any client that supports memcached TCP text protocol.
+Reliable reads would only work if client maintains persistent connection to the server
+between get requests.
+
+Here is a list of clients that would support reliable reads:
+
+## Ruby
+- [kestrel-client](https://github.com/freels/kestrel-client)
+- [memcache-client](https://github.com/mperham/memcache-client)
+
+## Go
+- [kklis/gomemcache](https://github.com/kklis/gomemcache)
+
+If you find other compatible clients,
+please don't hesitate to create a PR and update this list.

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -22,19 +22,19 @@ func Test_Open(t *testing.T) {
 	q, err := Open(name, dir)
 	defer q.Drop()
 	assert.Nil(t, err)
-	assert.Equal(t, q.Head(), uint64(0), "Invalid initial queue state")
-	assert.Equal(t, q.Tail(), uint64(0), "Invalid initial queue state")
-	assert.Equal(t, q.Length(), uint64(0), "Invalid initial queue state")
+	assert.Equal(t, uint64(0), q.Head(), "Invalid initial queue state")
+	assert.Equal(t, uint64(0), q.Tail(), "Invalid initial queue state")
+	assert.Equal(t, uint64(0), q.Length(), "Invalid initial queue state")
 
 	invalidQueueName := "%@#*(&($%@#"
 	q2, err := Open(invalidQueueName, dir)
 	defer q2.Drop()
-	assert.Equal(t, err.Error(), "Queue name is not alphanumeric")
+	assert.Equal(t, "Queue name is not alphanumeric", err.Error())
 
 	invalidQueueName = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	q3, err := Open(invalidQueueName, dir)
 	defer q3.Drop()
-	assert.Equal(t, err.Error(), "Queue name is too long")
+	assert.Equal(t, "Queue name is too long", err.Error())
 }
 
 func Test_Drop(t *testing.T) {
@@ -52,14 +52,14 @@ func Test_HeadTail(t *testing.T) {
 
 	for i := 1; i <= queueLength; i++ {
 		_ = q.Enqueue([]byte("1"))
-		assert.Equal(t, q.Head(), uint64(0))
-		assert.Equal(t, q.Tail(), uint64(i))
+		assert.Equal(t, uint64(0), q.Head())
+		assert.Equal(t, uint64(i), q.Tail())
 	}
 
 	for i := 1; i <= queueLength; i++ {
 		_, _ = q.Dequeue()
-		assert.Equal(t, q.Head(), uint64(i))
-		assert.Equal(t, q.Tail(), uint64(queueLength))
+		assert.Equal(t, uint64(i), q.Head())
+		assert.Equal(t, uint64(queueLength), q.Tail())
 	}
 
 }
@@ -75,7 +75,7 @@ func Test_Peek(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		item, err := q.Peek()
 		assert.Nil(t, err)
-		assert.Equal(t, string(item.Value), inputValue, "Invalid value")
+		assert.Equal(t, inputValue, string(item.Value), "Invalid value")
 	}
 }
 
@@ -93,14 +93,14 @@ func Test_EnqueueDequeueLength(t *testing.T) {
 	}
 
 	for i := 0; i < len(values); i++ {
-		assert.Equal(t, q.Length(), uint64(i))
+		assert.Equal(t, uint64(i), q.Length())
 		q.Enqueue([]byte(values[i]))
 	}
 
 	for i := 0; i < len(values); i++ {
 		item, err := q.Dequeue()
 		assert.Nil(t, err)
-		assert.Equal(t, string(item.Value), values[i], "Invalid value")
+		assert.Equal(t, values[i], string(item.Value), "Invalid value")
 	}
 
 }
@@ -117,16 +117,16 @@ func Test_Prepend(t *testing.T) {
 	item, _ := q.Dequeue()
 	q.Dequeue()
 
-	assert.Equal(t, q.Head(), uint64(2))
+	assert.Equal(t, uint64(2), q.Head())
 
 	err = q.Prepend(item)
 	assert.Nil(t, err)
 
-	assert.Equal(t, q.Head(), uint64(1))
+	assert.Equal(t, uint64(1), q.Head())
 
 	// Check that we get the same item with the next Dequeue
 	item, _ = q.Dequeue()
-	assert.Equal(t, string(item.Value), "1")
+	assert.Equal(t, "1", string(item.Value))
 }
 
 func Test_Length(t *testing.T) {
@@ -139,14 +139,14 @@ func Test_Length(t *testing.T) {
 	}
 
 	for i := 0; i < len(values); i++ {
-		assert.Equal(t, q.Length(), uint64(i))
+		assert.Equal(t, uint64(i), q.Length())
 		q.Enqueue([]byte(values[i]))
 	}
 
 	for i := len(values); i < 0; i-- {
 		_, err := q.Dequeue()
 		assert.Nil(t, err)
-		assert.Equal(t, q.Length(), uint64(i))
+		assert.Equal(t, uint64(i), q.Length())
 	}
 }
 
@@ -155,9 +155,9 @@ func Test_AddOpenTransactions(t *testing.T) {
 	defer q.Drop()
 
 	q.AddOpenTransactions(1)
-	assert.Equal(t, q.Stats.OpenTransactions, int64(1))
+	assert.Equal(t, int64(1), q.Stats.OpenTransactions)
 	q.AddOpenTransactions(-1)
-	assert.Equal(t, q.Stats.OpenTransactions, int64(0))
+	assert.Equal(t, int64(0), q.Stats.OpenTransactions)
 }
 
 func Test_initialize(t *testing.T) {
@@ -168,7 +168,7 @@ func Test_initialize(t *testing.T) {
 	q.Enqueue([]byte("2"))
 	q.Enqueue([]byte("3"))
 
-	assert.Equal(t, q.Length(), uint64(3))
+	assert.Equal(t, uint64(3), q.Length())
 
 	expectedLength := q.Length()
 	expectedHead := q.Head()
@@ -189,5 +189,5 @@ func Test_initialize(t *testing.T) {
 func Test_queuePath(t *testing.T) {
 	q, _ := Open("test_queue", dir)
 	defer q.Drop()
-	assert.Equal(t, q.Path(), "./test_data/test_queue")
+	assert.Equal(t, "./test_data/test_queue", q.Path())
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -12,7 +12,7 @@ import (
 	"github.com/streamrail/concurrent-map"
 )
 
-const Version = "siberite-0.2.2"
+const Version = "siberite-0.3"
 
 type QueueRepository struct {
 	storage  cmap.ConcurrentMap

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -48,13 +48,13 @@ func Test_Initialize(t *testing.T) {
 	repo, err = Initialize(dir)
 	assert.Nil(t, err)
 
-	assert.Equal(t, repo.Count(), 3, "Invalid repo count after initialization")
+	assert.Equal(t, 3, repo.Count(), "Invalid repo count after initialization")
 
 	for i := 0; i < len(queueNames); i++ {
 		q, _ = repo.GetQueue(queueNames[i])
-		assert.Equal(t, q.Head(), uint64(1), "Invalid queue initialization")
-		assert.Equal(t, q.Tail(), uint64(totalItems), "Invalid queue initialization")
-		assert.Equal(t, q.Length(), uint64(totalItems-1), "Invalid queue initialization")
+		assert.Equal(t, uint64(1), q.Head(), "Invalid queue initialization")
+		assert.Equal(t, uint64(totalItems), q.Tail(), "Invalid queue initialization")
+		assert.Equal(t, uint64(totalItems-1), q.Length(), "Invalid queue initialization")
 	}
 	repo.DeleteAllQueues()
 }
@@ -92,7 +92,7 @@ func Test_FullStats(t *testing.T) {
 	}
 
 	for i, statItem := range repo.FullStats() {
-		assert.Equal(t, statItemKeys[i], statItem.Key, "Invalid stats output")
+		assert.Equal(t, statItem.Key, statItemKeys[i], "Invalid stats output")
 	}
 }
 
@@ -102,5 +102,5 @@ func Test_Count(t *testing.T) {
 
 	repo.GetQueue("test1")
 	repo.GetQueue("test2")
-	assert.Equal(t, repo.Count(), 2)
+	assert.Equal(t, 2, repo.Count())
 }


### PR DESCRIPTION
- Implement GET <queue-name>/close/open
- Allow /t=<milliseconds> parameter
- Change flush_all response according to kestrel/darner
