### PR TITLE
Replace outdated link to memcached-client

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -8,7 +8,7 @@ Here is a list of clients that would support reliable reads:
 
 ## Ruby
 - [kestrel-client](https://github.com/freels/kestrel-client)
-- [memcache-client](https://github.com/mperham/memcache-client)
+- [dalli](https://github.com/mperham/dalli)
 
 ## Go
 - [kklis/gomemcache](https://github.com/kklis/gomemcache)


### PR DESCRIPTION
Link to memcached-client is outdated, on memcached-client github page it's recommended to use _dalli_ library instead of memcached-client.