### PR TITLE
Add fanout queues suppport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.1
+
+- Fanout queues support.<br>
+  `set <queue>+<another_queue>+<third_queue> ...` adds an item to multiple queues.
+
 ## 0.5
 
 - Add durable cursors. An ability to consume queue multiple times

--- a/README.md
+++ b/README.md
@@ -28,19 +28,24 @@ We used to use Darner before, but got 2 large production queues corrupted at som
 
 ## Features
 
-Multiple consumer groups per queue using `get <queue>:<cursor>` syntax.
+1. Multiple consumer groups per queue using `get <queue>:<cursor>` syntax.
 
-1. When you read an item in a usual way: `get <queue>`, an item gets expired and deleted.
-2. When you read an item using cursor `get <queue>:<cursor>`, a durable cursor gets initialized.
-   With every read it shifts forward without deleting any messages in the source queue.
-   So the source queue remains untouched. Number of cursors per queue is not limited.
-3. If you continue reads from the source queue directly, siberite will continue
-   deleting messages from the head of that queue. Any existing cursor that is
-   internally points to already deleted message will catch up during next read
-   and will start serving messages from the current source queue head.
-4. Durable cursors also support two-phase reliable reads. All failed reliable
-   reads for each cursor are stored in their own small persistent queues and get
-   served first.
+  - When you read an item in a usual way: `get <queue>`, item gets expired and deleted.
+  - When you read an item using cursor syntax `get <queue>:<cursor>`, a durable
+    cursor gets initialized. It shifts forward with every read without deleting
+    any messages in the source queue. Number of cursors per queue is not limited.
+  - If you continue reads from the source queue directly, siberite will continue
+    deleting messages from the head of that queue. Any existing cursor that is
+    internally points to an already deleted message will catch up during next read
+    and will start serving messages from the current source queue head.
+  - Durable cursors are also support two-phase reliable reads. All failed reliable
+    reads for each cursor are stored in cursor's own small persistent queue.
+
+2. Fanout queues
+
+  - Siberite allows you to insert new message into multiple queues at once
+    by using the following syntax `set <queue>+<another_queue>+<third_queue> ...`
+
 
 
 ##Benchmarks
@@ -123,10 +128,6 @@ END
 # delete work
 # flush_all
 ```
-
-## TODO
-
-  - Add fanout queues support
 
 
 ## Not supported

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -34,6 +34,7 @@ type Command struct {
 	QueueName     string
 	SubCommand    string
 	ConsumerGroup string
+	FanoutQueues  []string
 	DataSize      int
 }
 

--- a/controller/set.go
+++ b/controller/set.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"strconv"
+	"strings"
 	"sync/atomic"
 )
 
@@ -14,32 +15,32 @@ import (
 // <data block>
 // Response: STORED
 func (c *Controller) Set(input []string) error {
-	if len(input) < 5 || len(input) > 6 {
-		return &Error{"CLIENT_ERROR", "Invalid input"}
-	}
-
-	totalBytes, err := strconv.Atoi(input[4])
+	cmd, err := parseSetCommand(input)
 	if err != nil {
-		return &Error{"CLIENT_ERROR", "Invalid <bytes> number"}
+		return NewError("CLIENT_ERROR", err)
 	}
-
-	cmd := &Command{Name: input[0], QueueName: input[1], DataSize: totalBytes}
 
 	dataBlock, err := c.readDataBlock(cmd.DataSize)
 	if err != nil {
 		return NewError("CLIENT_ERROR", err)
 	}
 
-	q, err := c.repo.GetQueue(cmd.QueueName)
-	if err != nil {
-		log.Println(cmd, err)
-		return NewError("ERROR", err)
+	if cmd.FanoutQueues == nil {
+		err = c.storeDataBlock(cmd.QueueName, dataBlock)
+		if err != nil {
+			log.Println(cmd, err)
+			return NewError("ERROR", err)
+		}
+	} else {
+		for _, queueName := range cmd.FanoutQueues {
+			err = c.storeDataBlock(queueName, dataBlock)
+			if err != nil {
+				log.Println(cmd, err)
+				return NewError("ERROR", err)
+			}
+		}
 	}
 
-	err = q.Enqueue([]byte(dataBlock))
-	if err != nil {
-		return NewError("ERROR", err)
-	}
 	fmt.Fprint(c.rw.Writer, "STORED\r\n")
 	c.rw.Writer.Flush()
 	atomic.AddUint64(&c.repo.Stats.CmdSet, 1)
@@ -59,4 +60,31 @@ func (c *Controller) readDataBlock(totalBytes int) ([]byte, error) {
 	}
 
 	return dataBlock[:totalBytes], nil
+}
+
+func (c *Controller) storeDataBlock(queueName string, dataBlock []byte) error {
+	q, err := c.repo.GetQueue(queueName)
+	if err != nil {
+		return err
+	}
+	return q.Enqueue([]byte(dataBlock))
+}
+
+func parseSetCommand(input []string) (*Command, error) {
+	if len(input) < 5 || len(input) > 6 {
+		return nil, errors.New("Invalid input")
+	}
+
+	totalBytes, err := strconv.Atoi(input[4])
+	if err != nil {
+		return nil, errors.New("Invalid <bytes> number")
+	}
+
+	cmd := &Command{Name: input[0], QueueName: input[1], DataSize: totalBytes}
+
+	if strings.Contains(cmd.QueueName, "+") {
+		cmd.FanoutQueues = strings.Split(cmd.QueueName, "+")
+		cmd.QueueName = cmd.FanoutQueues[0]
+	}
+	return cmd, nil
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Version represents siberite version
-const Version = "siberite-0.5"
+const Version = "siberite-0.5.1"
 
 // QueueRepository represents a repository of queues
 type QueueRepository struct {


### PR DESCRIPTION
- Uses the following syntax to add messages to multiple queues at once

```
set <queue>+<second>+<third> 0 0 <messageSize>
data block\r\n
```

Implements #22 