### PR TITLE
Change durable cursor separator from ':' to '.' for Kestrel compat

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -12,6 +12,9 @@ import (
 	"github.com/bogdanovich/siberite/repository"
 )
 
+// consumer group separator
+const cgSeparator = "."
+
 // Conn represents a connection interface
 type Conn interface {
 	io.Reader
@@ -99,8 +102,8 @@ func (c *Controller) getConsumer(cmd *Command) (queue.Consumer, error) {
 func parseCommand(input []string) *Command {
 	cmd := &Command{Name: input[0], QueueName: input[1], SubCommand: ""}
 	tokens := make([]string, 3)
-	if strings.Contains(cmd.QueueName, ":") {
-		tokens = strings.SplitN(cmd.QueueName, ":", 3)
+	if strings.Contains(cmd.QueueName, cgSeparator) {
+		tokens = strings.SplitN(cmd.QueueName, cgSeparator, 3)
 		cmd.QueueName = tokens[0]
 		cmd.ConsumerGroup = tokens[1]
 	}

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -120,8 +120,8 @@ func Test_Controller_SendError(t *testing.T) {
 func Test_Controller_parseCommand(t *testing.T) {
 	testCases := map[string]Command{
 		"work":      Command{},
-		"work:cg":   Command{ConsumerGroup: "cg"},
-		"work:cg:1": Command{ConsumerGroup: "cg"},
+		"work.cg":   Command{ConsumerGroup: "cg"},
+		"work.cg.1": Command{ConsumerGroup: "cg"},
 	}
 
 	for input, command := range testCases {

--- a/controller/delete_test.go
+++ b/controller/delete_test.go
@@ -11,14 +11,14 @@ func Test_Controller_Delete(t *testing.T) {
 	defer cleanupControllerTest(repo)
 
 	// Create consumer group and get first item
-	command := []string{"get", "test:cgroup"}
+	command := []string{"get", "test.cgroup"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
 	assert.Equal(t, "VALUE test 0 1\r\n0\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
-	command = []string{"flush", "test:cgroup"}
+	command = []string{"flush", "test.cgroup"}
 	err = controller.Flush(command)
 	assert.Nil(t, err)
 	response, err := mockTCPConn.WriteBuffer.ReadString('\n')
@@ -28,7 +28,7 @@ func Test_Controller_Delete(t *testing.T) {
 	mockTCPConn.WriteBuffer.Reset()
 
 	// Still returns first item (because it was deleted before)
-	command = []string{"get", "test:cgroup"}
+	command = []string{"get", "test.cgroup"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
 	assert.Equal(t, "VALUE test 0 1\r\n0\r\nEND\r\n", mockTCPConn.WriteBuffer.String())

--- a/controller/flush_test.go
+++ b/controller/flush_test.go
@@ -11,14 +11,14 @@ func Test_Controller_Flush(t *testing.T) {
 	defer cleanupControllerTest(repo)
 
 	// Returns first item
-	command := []string{"get", "test:cgroup"}
+	command := []string{"get", "test.cgroup"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
 	assert.Equal(t, "VALUE test 0 1\r\n0\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
-	command = []string{"flush", "test:cgroup"}
+	command = []string{"flush", "test.cgroup"}
 	err = controller.Flush(command)
 	assert.Nil(t, err)
 	response, err := mockTCPConn.WriteBuffer.ReadString('\n')
@@ -28,7 +28,7 @@ func Test_Controller_Flush(t *testing.T) {
 	mockTCPConn.WriteBuffer.Reset()
 
 	// Still returns first item (because it was flushed before)
-	command = []string{"get", "test:cgroup"}
+	command = []string{"get", "test.cgroup"}
 	err = controller.Get(command)
 	assert.Nil(t, err)
 	assert.Equal(t, "VALUE test 0 1\r\n0\r\nEND\r\n", mockTCPConn.WriteBuffer.String())

--- a/controller/get.go
+++ b/controller/get.go
@@ -127,8 +127,8 @@ func parseGetCommand(input []string) *Command {
 		cmd.QueueName = tokens[0]
 		cmd.SubCommand = strings.Trim(tokens[1], "/")
 	}
-	if strings.Contains(cmd.QueueName, ":") {
-		tokens = strings.SplitN(cmd.QueueName, ":", 3)
+	if strings.Contains(cmd.QueueName, cgSeparator) {
+		tokens = strings.SplitN(cmd.QueueName, cgSeparator, 3)
 		cmd.QueueName = tokens[0]
 		cmd.ConsumerGroup = tokens[1]
 	}

--- a/controller/get_test.go
+++ b/controller/get_test.go
@@ -19,17 +19,17 @@ func Test_Controller_parseGetCommand(t *testing.T) {
 		"work/open/t=10":                  Command{SubCommand: "open"},
 		"work/close/open/t=10":            Command{SubCommand: "close/open"},
 		"work/close/t=10/open/abort":      Command{SubCommand: "close/open/abort"},
-		"work:cg":                         Command{ConsumerGroup: "cg"},
-		"work:consumer/open":              Command{SubCommand: "open", ConsumerGroup: "consumer"},
-		"work:1/close":                    Command{SubCommand: "close", ConsumerGroup: "1"},
-		"work:000/abort":                  Command{SubCommand: "abort", ConsumerGroup: "000"},
-		"work:1:2/peek":                   Command{SubCommand: "peek", ConsumerGroup: "1"},
-		"work:consumergroup/t=10":         Command{ConsumerGroup: "consumergroup"},
-		"work:test:cg/t=10/t=100/t=22":    Command{ConsumerGroup: "test"},
-		"work:1cg/t=10/open":              Command{SubCommand: "open", ConsumerGroup: "1cg"},
-		"work:c/open/t=10":                Command{SubCommand: "open", ConsumerGroup: "c"},
-		"work:0/close/open/t=10":          Command{SubCommand: "close/open", ConsumerGroup: "0"},
-		"work:group/close/t=1/open/abort": Command{SubCommand: "close/open/abort", ConsumerGroup: "group"},
+		"work.cg":                         Command{ConsumerGroup: "cg"},
+		"work.consumer/open":              Command{SubCommand: "open", ConsumerGroup: "consumer"},
+		"work.1/close":                    Command{SubCommand: "close", ConsumerGroup: "1"},
+		"work.000/abort":                  Command{SubCommand: "abort", ConsumerGroup: "000"},
+		"work.1:2/peek":                   Command{SubCommand: "peek", ConsumerGroup: "1:2"},
+		"work.consumergroup/t=10":         Command{ConsumerGroup: "consumergroup"},
+		"work.test.cg/t=10/t=100/t=22":    Command{ConsumerGroup: "test"},
+		"work.1cg/t=10/open":              Command{SubCommand: "open", ConsumerGroup: "1cg"},
+		"work.c/open/t=10":                Command{SubCommand: "open", ConsumerGroup: "c"},
+		"work.0/close/open/t=10":          Command{SubCommand: "close/open", ConsumerGroup: "0"},
+		"work.group/close/t=1/open/abort": Command{SubCommand: "close/open/abort", ConsumerGroup: "group"},
 	}
 
 	for input, command := range testCases {
@@ -45,7 +45,7 @@ func Test_Controller_Get(t *testing.T) {
 	repo, controller, mockTCPConn := setupControllerTest(t, 1)
 	defer cleanupControllerTest(repo)
 
-	queueNames := []string{"test:1", "test:cgroup", "test"}
+	queueNames := []string{"test.1", "test.cgroup", "test"}
 
 	for _, queueName := range queueNames {
 		// When queue has items
@@ -100,7 +100,7 @@ func Test_Controller_GetOpen(t *testing.T) {
 	repo, controller, mockTCPConn := setupControllerTest(t, 4)
 	defer cleanupControllerTest(repo)
 
-	queueNames := []string{"test:1", "test:cgroup", "test"}
+	queueNames := []string{"test.1", "test.cgroup", "test"}
 
 	for _, queueName := range queueNames {
 		// get queueName/open = value
@@ -183,7 +183,7 @@ func Test_Controller_GetOpen_Disconnect(t *testing.T) {
 	repo, controller, mockTCPConn := setupControllerTest(t, 2)
 	defer cleanupControllerTest(repo)
 
-	queueNames := []string{"test:1", "test:cgroup", "test"}
+	queueNames := []string{"test.1", "test.cgroup", "test"}
 
 	for _, queueName := range queueNames {
 		// get queueName/open = value
@@ -220,7 +220,7 @@ func Test_Controller_GetCloseOpen(t *testing.T) {
 	repo, controller, mockTCPConn := setupControllerTest(t, 4)
 	defer cleanupControllerTest(repo)
 
-	queueNames := []string{"test:1", "test:cgroup", "test"}
+	queueNames := []string{"test.1", "test.cgroup", "test"}
 
 	for _, queueName := range queueNames {
 		// get queueName/close/open = 1
@@ -285,7 +285,7 @@ func Test_Controller_Gets(t *testing.T) {
 	repo, controller, mockTCPConn := setupControllerTest(t, 2)
 	defer cleanupControllerTest(repo)
 
-	queueNames := []string{"test:1", "test:cgroup", "test"}
+	queueNames := []string{"test.1", "test.cgroup", "test"}
 
 	for _, queueName := range queueNames {
 		// gets test/open = 1
@@ -326,7 +326,7 @@ func Test_Controller_ConsumerGroup_Get(t *testing.T) {
 	repo, controller, mockTCPConn := setupControllerTest(t, 3)
 	defer cleanupControllerTest(repo)
 
-	command := []string{"get", "test:cgroup"}
+	command := []string{"get", "test.cgroup"}
 	err = controller.Get(command)
 	assert.NoError(t, err)
 	assert.Equal(t, "VALUE test 0 1\r\n0\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
@@ -347,14 +347,14 @@ func Test_Controller_ConsumerGroup_Get(t *testing.T) {
 
 	mockTCPConn.WriteBuffer.Reset()
 
-	command = []string{"get", "test:cgroup"}
+	command = []string{"get", "test.cgroup"}
 	err = controller.Get(command)
 	assert.NoError(t, err)
 	assert.Equal(t, "VALUE test 0 1\r\n2\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
 
 	mockTCPConn.WriteBuffer.Reset()
 
-	command = []string{"get", "test:cgroup"}
+	command = []string{"get", "test.cgroup"}
 	err = controller.Get(command)
 	assert.NoError(t, err)
 	assert.Equal(t, "END\r\n", mockTCPConn.WriteBuffer.String())
@@ -365,7 +365,7 @@ func Test_Controller_ConsumerGroup_Get(t *testing.T) {
 	assert.NoError(t, err)
 	q.Enqueue([]byte("3"))
 
-	command = []string{"get", "test:cgroup"}
+	command = []string{"get", "test.cgroup"}
 	err = controller.Get(command)
 	assert.NoError(t, err)
 	assert.Equal(t, "VALUE test 0 1\r\n3\r\nEND\r\n", mockTCPConn.WriteBuffer.String())
@@ -382,11 +382,11 @@ func Test_Controller_ConsumerGroup_GetAbort(t *testing.T) {
 	repo, controller, mockTCPConn := setupControllerTest(t, 3)
 	defer cleanupControllerTest(repo)
 
-	abortCommands := []string{"test/abort", "test:cgroup/abort"}
+	abortCommands := []string{"test/abort", "test.cgroup/abort"}
 
 	for _, abortCommand := range abortCommands {
 
-		command := []string{"get", "test:cgroup/open"}
+		command := []string{"get", "test.cgroup/open"}
 		err = controller.Get(command)
 		assert.NoError(t, err)
 		assert.Equal(t, "VALUE test 0 1\r\n0\r\nEND\r\n",
@@ -401,7 +401,7 @@ func Test_Controller_ConsumerGroup_GetAbort(t *testing.T) {
 
 		mockTCPConn.WriteBuffer.Reset()
 
-		command = []string{"get", "test:cgroup/peek"}
+		command = []string{"get", "test.cgroup/peek"}
 		err = controller.Get(command)
 		assert.NoError(t, err)
 		assert.Equal(t, "VALUE test 0 1\r\n0\r\nEND\r\n",

--- a/controller/stats_test.go
+++ b/controller/stats_test.go
@@ -34,10 +34,10 @@ func Test_Controller_Stats(t *testing.T) {
 		"STAT cmd_set 0\r\n" +
 		fmt.Sprintf("STAT queue_test_items %d\r\n", 3) +
 		"STAT queue_test_open_transactions 0\r\n" +
-		fmt.Sprintf("STAT queue_test:cg1_items %d\r\n", 2) +
-		"STAT queue_test:cg1_open_transactions 0\r\n" +
-		fmt.Sprintf("STAT queue_test:cg2_items %d\r\n", 1) +
-		"STAT queue_test:cg2_open_transactions 0\r\n" +
+		fmt.Sprintf("STAT queue_test.cg1_items %d\r\n", 2) +
+		"STAT queue_test.cg1_open_transactions 0\r\n" +
+		fmt.Sprintf("STAT queue_test.cg2_items %d\r\n", 1) +
+		"STAT queue_test.cg2_open_transactions 0\r\n" +
 		"END\r\n"
 	assert.Nil(t, err)
 	assert.Equal(t, statsResponse, mockTCPConn.WriteBuffer.String())

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -7,7 +7,7 @@ between get requests.
 Here is a list of clients that would support reliable reads:
 
 ## Ruby
-- [kestrel-client](https://github.com/twitter/kestrel-client)
+- [siberite-client](https://github.com/bogdanovich/siberite-ruby)
 - [memcache-client](https://github.com/mperham/memcache-client)
 
 ## Go

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -12,7 +12,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
-var alphaNumericRegexp = regexp.MustCompile(`[^a-zA-Z0-9_\-]+`)
+var validQueueNameRegex = regexp.MustCompile(`[^a-zA-Z0-9_\-\:]+`)
 
 // Consumer represents a queue consumer
 type Consumer interface {
@@ -247,7 +247,7 @@ func (q *Queue) Path() string {
 }
 
 func (q *Queue) open() error {
-	if alphaNumericRegexp.MatchString(q.Name) {
+	if validQueueNameRegex.MatchString(q.Name) {
 		return errors.New("queue: name is not alphanumeric")
 	}
 

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Version represents siberite version
-const Version = "siberite-0.5.2"
+const Version = "siberite-0.6.0"
 
 // QueueRepository represents a repository of queues
 type QueueRepository struct {
@@ -145,8 +145,8 @@ func (repo *QueueRepository) FullStats() []StatItem {
 		stats = append(stats, StatItem{"queue_" + q.Name + "_open_transactions", fmt.Sprintf("%d", q.Stats().OpenReads)})
 		for pair := range q.ConsumerGroupIterator() {
 			cg = pair.Val.(*cgroup.ConsumerGroup)
-			stats = append(stats, StatItem{"queue_" + q.Name + ":" + cg.Name + "_items", fmt.Sprintf("%d", cg.Length())})
-			stats = append(stats, StatItem{"queue_" + q.Name + ":" + cg.Name + "_open_transactions", fmt.Sprintf("%d", cg.Stats().OpenReads)})
+			stats = append(stats, StatItem{"queue_" + q.Name + "." + cg.Name + "_items", fmt.Sprintf("%d", cg.Length())})
+			stats = append(stats, StatItem{"queue_" + q.Name + "." + cg.Name + "_open_transactions", fmt.Sprintf("%d", cg.Stats().OpenReads)})
 		}
 	}
 	return stats

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -101,24 +101,28 @@ func Test_GetQueue(t *testing.T) {
 	defer repo.DeleteAllQueues()
 
 	_, err := repo.GetQueue("test1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, repo.Count())
 
 	_, err = repo.GetQueue("test1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, repo.Count())
 
 	_, err = repo.GetQueue("test2")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, repo.Count())
 
-	_, err = repo.GetQueue("test:test")
-	assert.Equal(t, "queue: name is not alphanumeric", err.Error())
-	assert.Equal(t, 2, repo.Count())
+	_, err = repo.GetQueue("test2:test2")
+	assert.NoError(t, err)
+	assert.Equal(t, 3, repo.Count())
+
+	_, err = repo.GetQueue("test.test")
+	assert.EqualError(t, err, "queue: name is not alphanumeric")
+	assert.Equal(t, 3, repo.Count())
 
 	_, err = repo.GetQueue("testtest!@#$%^&*-=")
 	assert.Equal(t, "queue: name is not alphanumeric", err.Error())
-	assert.Equal(t, 2, repo.Count())
+	assert.Equal(t, 3, repo.Count())
 }
 
 func Test_Count(t *testing.T) {


### PR DESCRIPTION
- Bump version to 0.6.0
- Add siberite-client ruby link