### PR TITLE
Add support of 'quit' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.3
+- Added support for 'quit' command (memcached protocol compatibility)
+
 ## 0.6.2
 - Limit OpenFilesCacheCapacity to 64 per queue
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ END
 # flush work
 # delete work
 # flush_all
+# quit
 ```
 
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -38,6 +38,9 @@ var (
 
 	// ErrInvalidDataSize is returned when data size field is not a number
 	ErrInvalidDataSize = &Error{clientError, "Invalid <bytes> number"}
+
+	// ErrClientQuit is returned when client sends 'quit' command (not an error)
+	ErrClientQuit = &Error{commonError, "Quit command received"}
 )
 
 // Conn represents a connection interface

--- a/controller/dispatch.go
+++ b/controller/dispatch.go
@@ -33,6 +33,8 @@ func (c *Controller) Dispatch() error {
 		err = c.Flush(command)
 	case "flush_all":
 		err = c.FlushAll()
+	case "quit":
+		return ErrClientQuit
 	default:
 		return c.UnknownCommand()
 	}

--- a/controller/dispatch_test.go
+++ b/controller/dispatch_test.go
@@ -142,4 +142,11 @@ func Test_Controller_Dispatch(t *testing.T) {
 	err = controller.Dispatch()
 	assert.Nil(t, err)
 	assert.Equal(t, "Flushed all queues.\r\n", mockTCPConn.WriteBuffer.String())
+
+	// Command: quit
+	fmt.Fprintf(&mockTCPConn.ReadBuffer, "quit\r\n")
+	err = controller.Dispatch()
+	assert.Error(t, err, "Quit command received")
+
+	mockTCPConn.WriteBuffer.Reset()
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Version represents siberite version
-const Version = "siberite-0.6.2"
+const Version = "siberite-0.6.3"
 
 // QueueRepository represents a repository of queues
 type QueueRepository struct {


### PR DESCRIPTION
- Added support for 'quit' command (memcached protocol compatibility)

Fixes [issue](https://github.com/bogdanovich/siberite-ruby/issues/5) with siberite-ruby

Closes #36