### PR TITLE
Add flag to allow specifying a PID file

### DIFF
--- a/siberite.go
+++ b/siberite.go
@@ -3,11 +3,13 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net"
 	"os"
 	"os/signal"
 	"runtime"
+	"strconv"
 	"syscall"
 
 	service "github.com/bogdanovich/siberite/service"
@@ -16,6 +18,7 @@ import (
 var (
 	dataDir     = flag.String("data", "./data", "path to data directory")
 	hostAndPort = flag.String("listen", "0.0.0.0:22133", "ip and port to listen")
+	pidPath     = flag.String("pid", "", "path to PID file to use")
 	versionFlag = flag.Bool("version", false, "prints current version")
 )
 
@@ -30,6 +33,15 @@ func main() {
 		os.Exit(0)
 	}
 
+	// Write a PID file if its requested
+	if len(*pidPath) > 0 {
+		err := ioutil.WriteFile(*pidPath, []byte(strconv.Itoa(os.Getpid())), 0644)
+		if nil != err {
+			log.Fatalln(err)
+		}
+		defer os.Remove(*pidPath)
+	}
+	
 	laddr, err := net.ResolveTCPAddr("tcp", *hostAndPort)
 	if nil != err {
 		log.Fatalln(err)


### PR DESCRIPTION
I had a use case where I needed a PID file associated with the Siberite server and after finding that it doesn't support it, added a simple implementation. I just added a flag `-pid` that allows you to specify one but may be omitted so it should be backwards compatible with existing functionality.

I'm a novice to Golang so please fix it up where if I've done something silly. 