### PR TITLE
Fix minor concurrency issues

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -211,7 +211,7 @@ func (q *Queue) Peek() ([]byte, error) {
 // ReadItemByID returns a value by it's id
 func (q *Queue) ReadItemByID(id uint64) (*Item, error) {
 	q.RLock()
-	q.RUnlock()
+	defer q.RUnlock()
 	return q.readItemByID(id)
 }
 
@@ -232,7 +232,7 @@ func (q *Queue) readItemByID(id uint64) (*Item, error) {
 // ReadItemByOffset returns an item by offset from the queue head, starting from 0.
 func (q *Queue) ReadItemByOffset(offset uint64) (*Item, error) {
 	q.RLock()
-	q.RUnlock()
+	defer q.RUnlock()
 	return q.readItemByID(q.head + 1 + offset)
 }
 

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -60,6 +60,14 @@ func (repo *QueueRepository) GetQueue(key string) (*cgroup.CGQueue, error) {
 
 	repo.Lock()
 	defer repo.Unlock()
+
+	// now that we have acquired the lock, recheck to see if someone else
+	// already managed to create the queue while we were waiting on the lock
+	if q, ok := repo.get(key); ok {
+		return q, nil
+	}
+
+	// ok, we are the first - create the queue
 	q, err := cgroup.CGQueueOpen(key, repo.DataPath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fix a race condition that can occur when two (or more) clients
attempt to create a queue with the same name at the same time.

Make sure that read unlocks are deferred after acquiring the
read lock.