### PR TITLE
Sanity check input queue name length

### DIFF
--- a/controller/delete.go
+++ b/controller/delete.go
@@ -25,7 +25,7 @@ func (c *Controller) Delete(input []string) error {
 	}
 
 	if err != nil {
-		log.Printf("Command %s: %s ", cmd, err.Error())
+		log.Printf("Command %s: %s ", cmd.Name, err.Error())
 		return NewError(commonError, err)
 	}
 	fmt.Fprint(c.rw.Writer, endMessage)

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -270,7 +270,7 @@ func (q *Queue) Path() string {
 }
 
 func (q *Queue) open() error {
-	if validQueueNameRegex.MatchString(q.Name) {
+	if validQueueNameRegex.MatchString(q.Name) || len(q.Name) < 1 {
 		return ErrInvalidName
 	}
 

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -46,6 +46,11 @@ func Test_ValidQueueName(t *testing.T) {
 	assert.EqualError(t, err, "queue: name is not alphanumeric")
 	q.Drop()
 
+	invalidQueueName = ""
+	q, err = Open(invalidQueueName, dir, &options)
+	assert.EqualError(t, err, "queue: name is not alphanumeric")
+	q.Drop()
+
 	validQueueNames := []string{"test-name-1", "test_name_2"}
 	for _, queueName := range validQueueNames {
 		q, err = Open(queueName, dir, &options)


### PR DESCRIPTION
This fixes a case where sending a command like "get /peek" causes
the creation of a queue with an invalid name.  This invalid queue
name is persisted to the leveldb data store and subsequently
prevents siberite from starting successfully.