### PR TITLE
feat(get): add t=ms long-poll support (poll-based)

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -68,6 +68,7 @@ type Command struct {
 	ConsumerGroup string
 	FanoutQueues  []string
 	DataSize      int
+        TimeoutMs     int
 }
 
 // NewSession creates and initializes new controller

--- a/controller/get.go
+++ b/controller/get.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"sync/atomic"
+	"time"
 )
 
 var timeoutRegexp = regexp.MustCompile(`(t\=\d+)\/?`)
@@ -55,7 +56,17 @@ func (c *Controller) get(cmd *Command) error {
 		log.Println(cmd, err)
 		return NewError(commonError, err)
 	}
-	value, _ := q.GetNext()
+    value, _ := q.GetNext()
+    if len(value) == 0 && cmd.TimeoutMs > 0 {
+        deadline := time.Now().Add(time.Duration(cmd.TimeoutMs) * time.Millisecond)
+        for time.Now().Before(deadline) {
+            time.Sleep(10 * time.Millisecond)
+            value, _ = q.GetNext()
+            if len(value) > 0 {
+                break
+            }
+        }
+    }
 	if len(value) > 0 {
 		fmt.Fprintf(c.rw.Writer, "VALUE %s 0 %d\r\n", cmd.QueueName, len(value))
 		fmt.Fprintf(c.rw.Writer, "%s\r\n", value)
@@ -117,10 +128,23 @@ func (c *Controller) peek(cmd *Command) error {
 }
 
 func parseGetCommand(input []string) *Command {
-	cmd := &Command{Name: input[0], QueueName: input[1], SubCommand: ""}
-	if strings.Contains(input[1], "t=") {
-		input[1] = timeoutRegexp.ReplaceAllString(input[1], "")
-	}
+    cmd := &Command{Name: input[0], QueueName: input[1], SubCommand: ""}
+    if strings.Contains(input[1], "t=") {
+        // parse last t= value and strip from queue spec
+        matches := timeoutRegexp.FindAllString(input[1], -1)
+        if len(matches) > 0 {
+            last := matches[len(matches)-1] // e.g., "t=5000"
+            n := 0
+            s := last[2:]
+            for i := 0; i < len(s); i++ {
+                c := s[i]
+                if c < '0' || c > '9' { n = 0; break }
+                n = n*10 + int(c-'0')
+            }
+            cmd.TimeoutMs = n
+        }
+        input[1] = timeoutRegexp.ReplaceAllString(input[1], "")
+    }
 	tokens := make([]string, 3)
 	if strings.Contains(input[1], "/") {
 		tokens = strings.SplitN(input[1], "/", 2)

--- a/controller/get_longpoll_test.go
+++ b/controller/get_longpoll_test.go
@@ -1,0 +1,59 @@
+package controller
+
+import (
+	"bufio"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Controller_Get_LongPoll_Timeout(t *testing.T) {
+    repo, controller, mockTCPConn := setupControllerTest(t, 0)
+    defer cleanupControllerTest(repo)
+
+    start := time.Now()
+    err = controller.Get([]string{"get", "test/t=30"})
+    dur := time.Since(start)
+    assert.Nil(t, err)
+    assert.Equal(t, "END\r\n", mockTCPConn.WriteBuffer.String())
+    // should wait at least ~30ms (allow slack)
+    if dur < 25*time.Millisecond {
+        t.Fatalf("expected wait >=25ms, got %v", dur)
+    }
+}
+
+func Test_Controller_Get_LongPoll_Notify(t *testing.T) {
+    repo, controller, mockTCPConn := setupControllerTest(t, 0)
+    defer cleanupControllerTest(repo)
+
+    // Enqueue after a short delay while GET waits
+    done := make(chan struct{})
+    go func() {
+        defer close(done)
+        _ = controller.Get([]string{"get", "test/t=200"})
+    }()
+
+    time.Sleep(50 * time.Millisecond)
+    q, err := repo.GetQueue("test")
+    assert.NoError(t, err)
+    q.Enqueue([]byte(strconv.Itoa(1)))
+
+    select {
+    case <-done:
+        // ok
+    case <-time.After(500 * time.Millisecond):
+        t.Fatalf("GET did not return after enqueue")
+    }
+
+    // Verify VALUE response
+    rd := bufio.NewReader(&mockTCPConn.WriteBuffer)
+    line, _ := rd.ReadString('\n')
+    assert.Equal(t, "VALUE test 0 1\r\n", line)
+    body, _ := rd.ReadString('\n')
+    assert.Equal(t, fmt.Sprintf("%d\r\n", 1), body)
+}
+
+


### PR DESCRIPTION
Add simple long-polling for GET with t=ms.
- Parse t=ms and hold until item arrives or timeout.
- Backwards compatible when t not specified.
- Includes tests for timeout and notify scenarios.